### PR TITLE
move slim to lastest (Replace pure python instead of circleci)

### DIFF
--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -1,7 +1,9 @@
-FROM    circleci/python:3.7
+FROM    python:3.7
 USER    root
-RUN     apt-get update -y && apt-get install ffmpeg -y && \
+RUN     apt-get update -y && \
+        apt-get install ffmpeg -y && \
+        apt-get install curl -y && \
         apt-get autoremove -y && \
-        apt-get clean -y
-RUN     curl -sSL https://sdk.cloud.google.com | bash
+        apt-get clean -y && \
+        curl -sSL https://sdk.cloud.google.com | bash
 ENV     PATH $PATH:/root/google-cloud-sdk/bin


### PR DESCRIPTION
## Changes
- Jira Ticket: [DATACENTER-620]
- Circle CI 용 python 이미지를 pure python 이미지로 변경

[DATACENTER-620]: https://beprocompany.atlassian.net/browse/DATACENTER-620