### PR TITLE
[DATACENTER-1266] bepro-python, bepro-python-api에 사용할 docker image를 추가합니다.

### DIFF
--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -1,9 +1,42 @@
-FROM    python:3.7.8
-USER    root
-RUN     apt-get update -y && \
-        apt-get install ffmpeg -y && \
-        apt-get install curl -y && \
-        apt-get autoremove -y && \
-        apt-get clean -y && \
-        curl -sSL https://sdk.cloud.google.com | bash
-ENV     PATH $PATH:/root/google-cloud-sdk/bin
+# ffmpeg 빌드를 위한 도커 이미지
+# https://hub.docker.com/r/jrottenberg/ffmpeg/dockerfile
+FROM jrottenberg/ffmpeg:4.3-ubuntu1804 as base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl=7.58.0-2ubuntu3.9 \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists*
+
+ENV GOOGLE_CLOUD_SDK_VERSION=303.0.0
+WORKDIR /google-cloud/src
+RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+    && tar xvzf google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+    && rm google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+
+
+FROM python:3.7-slim as release
+
+# ffmpeg과 관련된 libgomp1 라이브러리 설치
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgomp1 \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists*
+
+# google-cloud-sdk 설치 
+WORKDIR /google-cloud-sdk
+COPY --from=base /google-cloud/src/google-cloud-sdk /google-cloud-sdk
+RUN ./install.sh \
+     --usage-reporting=false \
+     --path-update=true \
+     --bash-completion=true \
+     --rc-path=/.bashrc \
+     --quiet
+
+# ffmpeg, ffprobe 바이너리 설치
+COPY --from=base /usr/local /usr/local/
+
+# gcloud binary PATH 추가
+ENV PATH $PATH:/google-cloud-sdk/bin
+
+# ffmpeg 라이브러리 연동
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -17,8 +17,9 @@ RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google
 FROM python:3.7-slim as release
 
 # ffmpeg과 관련된 libgomp1 라이브러리 설치
+# bepro-python과 관련된 procps, gcc, git 설치
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1 procps \
+    && apt-get install -y --no-install-recommends libgomp1 procps gcc git \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -21,7 +21,10 @@ FROM python:3.7-slim as release
 # ffmpeg과 관련된 libgomp1 라이브러리 설치
 # bepro-python과 관련된 procps, gcc, git 설치
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1 procps gcc git \
+    && apt-get install -y --no-install-recommends libgomp1=8.3.0-6 \
+       procps=2:3.3.15-2 \ 
+       gcc=4:8.3.0-1 \ 
+       git=1:2.20.1-2+deb10u3 \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.7-slim as release
 
 # ffmpeg과 관련된 libgomp1 라이브러리 설치
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1 \
+    && apt-get install -y --no-install-recommends libgomp1 procps \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 
+# google-cloud-sdk 다운로드
+# 버전 고정 처리
 ENV GOOGLE_CLOUD_SDK_VERSION=303.0.0
 WORKDIR /google-cloud/src
 RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \

--- a/python_with_ffmpeg/build.sh
+++ b/python_with_ffmpeg/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-docker build -t bepro/python_with_ffmpeg .
+docker build -t "python_with_ffmpeg:3.7" -t "python_with_ffmpeg" .
+docker tag python_with_ffmpeg:latest bepro/python_with_ffmpeg:latest
+docker tag python_with_ffmpeg:3.7 bepro/python_with_ffmpeg:3.7
 docker push bepro/python_with_ffmpeg:latest
+docker push bepro/python_with_ffmpeg:3.7


### PR DESCRIPTION
## Changes
- Jira Ticket: [DATACENTER-1266]
- 기존 python:3.7.8로 설치를 하는 경우 debian:buster의 ffmpeg 4.1.6을 설치하기 때문에 4.3.x를 지원하는 docker image를 사용하도록 변경합니다.
- cloud-sdk를 3.0.2 지정 버전을 사용하도록 합니다.
- docker image 사이즈를 줄입니다.


[DATACENTER-1266]: https://beprocompany.atlassian.net/browse/DATACENTER-1266