### PR TITLE
qr_lipsync.sh error fix for arm64

### DIFF
--- a/stitching_base/Dockerfile.arm64
+++ b/stitching_base/Dockerfile.arm64
@@ -12,7 +12,7 @@ RUN \
        automake libtool unzip nasm yasm checkinstall cmake pkg-config yasm git gfortran libjpeg8-dev \
        libpng-dev libx264-dev libx265-dev libnuma-dev libvpx-dev libfdk-aac-dev libmp3lame-dev libopus-dev \
        libssh-dev gnutls-bin libgnutls28-dev libavdevice-dev libtiff-dev libavcodec-dev libavformat-dev \
-       libswscale-dev libavutil-dev libavresample-dev libdc1394-22-dev libxine2-dev libv4l-dev && \
+       libswscale-dev libavutil-dev libavresample-dev libdc1394-22-dev libxine2-dev libv4l-dev ffmpeg && \
       # use python 3.7
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
       update-alternatives --config python3 && \
@@ -35,7 +35,9 @@ RUN \
       # dvc work around
       pip install pygit2 && \
       pip install --no-cache-dir --exists-action w 'dvc[gs]' && \
-      pip install gcovr
+      pip install gcovr && \
+      # qr-libsynch for python3.6
+      python3.6 -m pip install setuptools
 WORKDIR /root
 
 # is this used?

--- a/stitching_base/qr-lipsync.sh
+++ b/stitching_base/qr-lipsync.sh
@@ -8,5 +8,6 @@ cd qr-lipsync
 # default python 3
 python3 setup.py install
 
-# python 3.6
+# python 3.6 (adding setuptools for arm64's python3.6)
+python3.6 -m pip install setuptools
 which python3.6 && python3.6 setup.py install

--- a/stitching_base/qr-lipsync.sh
+++ b/stitching_base/qr-lipsync.sh
@@ -9,5 +9,9 @@ cd qr-lipsync
 python3 setup.py install
 
 # python 3.6 (adding setuptools for arm64's python3.6)
-python3.6 -m pip install setuptools
+if which python3.6
+then
+    python3.6 -m pip install setuptools
+    python3.6 setup.py install
+fi
 which python3.6 && python3.6 setup.py install

--- a/stitching_base/qr-lipsync.sh
+++ b/stitching_base/qr-lipsync.sh
@@ -7,11 +7,4 @@ cd qr-lipsync
 
 # default python 3
 python3 setup.py install
-
-# python 3.6 (adding setuptools for arm64's python3.6)
-if which python3.6
-then
-    python3.6 -m pip install setuptools
-    python3.6 setup.py install
-fi
 which python3.6 && python3.6 setup.py install


### PR DESCRIPTION
in arm64 case, there is no setuptools for python3.6.
python 3.6 is only used in stitching_base/qr-lipsync.sh  file. so I added in the file not in the Dockerfile.arm64.
