### PR TITLE
220823 update ffmpeg 5

### DIFF
--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -1,7 +1,13 @@
+# syntax=docker/dockerfile:1
 FROM jrottenberg/ffmpeg:5.1-ubuntu2004
 
+# Install base packages
+# - python
+# - wget for gcloud download
+# - locales for setup locale
+# - cairo for CairoSVG
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl python3 python3-pip wget locales \
+    && apt-get install -y --no-install-recommends python3 python3-pip locales libcairo2 \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 
@@ -12,8 +18,8 @@ ENV LC_ALL en_US.UTF-8
 # google-cloud-sdk
 ARG GOOGLE_CLOUD_SDK_VERSION=396.0.0-linux-x86_64
 WORKDIR /google-cloud-sdk
-RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz \
-    && tar xf google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz --strip-components=1 \
+ADD --link https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz .
+RUN tar xf google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz --strip-components=1 \
     && rm google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz
 
 RUN ./install.sh \

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -1,53 +1,24 @@
-# ffmpeg 빌드를 위한 도커 이미지
-# https://hub.docker.com/r/jrottenberg/ffmpeg/dockerfile
-FROM jrottenberg/ffmpeg:4.3-ubuntu1804 as base
+FROM jrottenberg/ffmpeg:5.1-ubuntu2004
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl python3 python3-pip wget locales \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 
-# google-cloud-sdk 다운로드
-# 버전 고정 처리
-ENV GOOGLE_CLOUD_SDK_VERSION=303.0.0
-WORKDIR /google-cloud/src
-RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
-    && tar xvzf google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
-    && rm google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+# Setup locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LC_ALL en_US.UTF-8
 
-
-FROM python:3.7-slim-bullseye as release
-
-# ffmpeg과 관련된 libgomp1 라이브러리 설치
-# opencv와 관련된 libglib2, libgl1-mesa-glx 라이브러리 설치
-# bepro-python과 관련된 procps, gcc, git 설치
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1=10.2.1-6 \
-       procps=2:3.3.17-5 \
-       gcc=4:10.2.1-1 \
-       git=1:2.30.2-1 \
-       libc6-dev=2.31-13+deb11u3 \
-       libglib2.0-0 \
-       libgl1-mesa-glx \
-       libcairo2 \
-    && apt-get purge -y --auto-remove \
-    && rm -rf /var/lib/apt/lists*
-
-# google-cloud-sdk 설치 
+# google-cloud-sdk
+ARG GOOGLE_CLOUD_SDK_VERSION=396.0.0-linux-x86_64
 WORKDIR /google-cloud-sdk
-COPY --from=base /google-cloud/src/google-cloud-sdk /google-cloud-sdk
+RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz \
+    && tar xf google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz --strip-components=1 \
+    && rm google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz
+
 RUN ./install.sh \
-     --usage-reporting=false \
-     --path-update=true \
-     --bash-completion=true \
-     --rc-path=/.bashrc \
+     --usage-reporting false \
+     --path-update true \
      --quiet
 
-# ffmpeg, ffprobe 바이너리 설치
-COPY --from=base /usr/local /usr/local/
-
-# gcloud binary PATH 추가
-ENV PATH=$PATH:/google-cloud-sdk/bin
-
-# ffmpeg 라이브러리 연동
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+ENTRYPOINT [ "bash" ]

--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -6,8 +6,10 @@ FROM jrottenberg/ffmpeg:5.1-ubuntu2004
 # - wget for gcloud download
 # - locales for setup locale
 # - cairo for CairoSVG
+# - wget for transparent dependencies in graphic-video
+# - git for dependencies installation described as git
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip locales libcairo2 \
+    && apt-get install -y --no-install-recommends python3 python3-pip locales libcairo2 wget git \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists*
 

--- a/python_with_ffmpeg/build.sh
+++ b/python_with_ffmpeg/build.sh
@@ -2,18 +2,18 @@
 
 docker build -t "python_with_ffmpeg:3.8" .
 docker tag python_with_ffmpeg:latest bepro/python_with_ffmpeg:latest
-docker tag python_with_ffmpeg:3.7 bepro/python_with_ffmpeg:3.7
+docker tag python_with_ffmpeg:3.8 bepro/python_with_ffmpeg:3.8
 
 docker push bepro/python_with_ffmpeg:latest
-docker push bepro/python_with_ffmpeg:3.7
+docker push bepro/python_with_ffmpeg:3.8
 
 # CR_USER: github user id
 # CR_PAT: https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-github-container-registry
 if [[ $CR_USER ]] && [[ $CR_PAT ]]
 then
-  docker tag bepro/python_with_ffmpeg:3.7 ghcr.io/bepro-company/docker/python_with_ffmpeg:3.7
+  docker tag bepro/python_with_ffmpeg:3.8 ghcr.io/bepro-company/docker/python_with_ffmpeg:3.8
   echo $CR_PAT | docker login ghcr.io -u $CR_USER --password-stdin
-  docker push ghcr.io/bepro-company/docker/python_with_ffmpeg:3.7
+  docker push ghcr.io/bepro-company/docker/python_with_ffmpeg:3.8
 else
   echo "CR_USER, CR_PAT environment variables required!"
 fi

--- a/python_with_ffmpeg/build.sh
+++ b/python_with_ffmpeg/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker build -t "python_with_ffmpeg:3.7" -t "python_with_ffmpeg" .
+docker build -t "python_with_ffmpeg:3.8" .
 docker tag python_with_ffmpeg:latest bepro/python_with_ffmpeg:latest
 docker tag python_with_ffmpeg:3.7 bepro/python_with_ffmpeg:3.7
 

--- a/python_with_ffmpeg/build.sh
+++ b/python_with_ffmpeg/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker build -t "python_with_ffmpeg:3.8" .
+docker build -t "python_with_ffmpeg:3.8" -t "python_with_ffmpeg" .
 docker tag python_with_ffmpeg:latest bepro/python_with_ffmpeg:latest
 docker tag python_with_ffmpeg:3.8 bepro/python_with_ffmpeg:3.8
 


### PR DESCRIPTION
## Changes
During ffmpeg version 5 update, lots of things are changed.

1. Use pre-compiled ffmpeg docker image. Doesn't depend on OS' default package repository version
2. Update Ubuntu version from 1804 to 2004.
    - It allows builtin python 3.8 usage. 3.8 is almost compatible.
3. Moved locale configuration from private repository to this one.
4. Apply `add --link` syntax. It helps build speed since it can cache its contents even previous stage is invalidated.
5. Update gcloud cli version
6. Move libcairo installation into base image.
7. Remove Korean comments.