### PR TITLE
fix gcloud cli path problem

### DIFF
--- a/python_with_ffmpeg/Dockerfile
+++ b/python_with_ffmpeg/Dockerfile
@@ -1,5 +1,17 @@
 # syntax=docker/dockerfile:1
-FROM jrottenberg/ffmpeg:5.1-ubuntu2004
+FROM jrottenberg/ffmpeg:5.1-ubuntu2004 AS base
+
+WORKDIR /google-cloud-cli
+
+FROM base AS google_cloud_cli_downloader
+
+# google-cloud-cli
+ARG GOOGLE_CLOUD_CLI_VERSION=396.0.0-linux-x86_64
+ADD --link https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}.tar.gz .
+RUN tar xf google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}.tar.gz --strip-components=1 \
+    && rm google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}.tar.gz
+
+FROM base AS builder
 
 # Install base packages
 # - python
@@ -7,26 +19,20 @@ FROM jrottenberg/ffmpeg:5.1-ubuntu2004
 # - locales for setup locale
 # - cairo for CairoSVG
 # - wget for transparent dependencies in graphic-video
+# - curl for metadata query in Google compute engine VM
 # - git for dependencies installation described as git
 # - glib for cv2 contrib module dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt update \
-    && apt install -y --no-install-recommends python3 python3-pip locales libcairo2 wget git libglib2.0-0 \
+    && apt install -y --no-install-recommends python3 python3-pip locales libcairo2 wget curl git libglib2.0-0 \
     && apt purge -y --auto-remove
 
 # Setup locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 ENV LC_ALL en_US.UTF-8
 
-# google-cloud-sdk
-ARG GOOGLE_CLOUD_SDK_VERSION=396.0.0-linux-x86_64
-WORKDIR /google-cloud-sdk
-ADD --link https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz .
-RUN tar xf google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz --strip-components=1 \
-    && rm google-cloud-cli-${GOOGLE_CLOUD_SDK_VERSION}.tar.gz
+COPY --link --from=google_cloud_cli_downloader /google-cloud-cli/ /google-cloud-cli/
 
-RUN ./install.sh \
-     --usage-reporting false \
-     --path-update true \
-     --quiet
+RUN ./install.sh --usage-reporting false --quiet
+ENV PATH /google-cloud-cli/bin:$PATH
 
 ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
## Changes
- Install curl in base image. Used in compute engine VM metadata query
- Force PATH env variable.
    - There are lots of case to run gcloud cli in (bash, sh) x (interactive, noninteractive). The simplest soluation is forcing $PATH in dockerfile.
- Divide cli downloading and extracting into separate stage to optimize build speed and storage.
